### PR TITLE
Write the whole KML file at once

### DIFF
--- a/app/src/main/java/com/ds/avare/StorageService.java
+++ b/app/src/main/java/com/ds/avare/StorageService.java
@@ -487,7 +487,7 @@ public class StorageService extends Service {
 
                     // Adjust the flight timer
                     getFlightTimer().setSpeed(mGpsParams.getSpeed());
-                    
+
                     // Tell the KML recorder a new point to potentially plot
                     getKMLRecorder().setGpsParams(mGpsParams);
                     


### PR DESCRIPTION
Currently the KML file is opened when tracking is selected, the code writes just the header then writes the gps coordinates in the header as the reports arrive, once tracking is stopped the header is closed and the individual GPS coordinates are then written and the KML is closed out, there are a couple of issues with this;

1) We have a file open the whole time tracks are being recorded that does not have useful information in it, just the kml header and the "coordinate" data that isn't complete
2) On error there is often 0 length files left as the data isn't flushed due to the buffer being 8k
3) Results in user grief https://groups.google.com/forum/#!msg/apps4av-forum/tSn3NO7E56I/J-cpIiO3AQAJ

This change writes a complete KML file every 5 minutes while tracking and when tracks off is selected so the user should have a usable file at all times.

